### PR TITLE
Add rake

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,14 @@ after  'deploy:update_code', 'db:migrate', 'db:seed', 'deploy:after_party'
 
 This will ensure your deploy tasks always run after your migrations, so they can safely load or interact with any models in your system.
 
+You can also reset the list of executed tasks by running:
+
+```console
+rake after_party:reset
+```
+
+This will allow all tasks to be re-run the next time `rake after_party:run` is executed.  While you probably wouldn't want to execute the above command on a production database, it can be handy while working in development.
+
 ##Asyncronous runs
 
 Well yes, a long-running deploy task will halt your deployment, thanks for noticing.  Sometimes you might want your task to finish before you switch the symlink and your new code is in production.  Sometimes, you just want to start the task, and forget about it.  In that case do this:

--- a/lib/after_party/railtie.rb
+++ b/lib/after_party/railtie.rb
@@ -1,11 +1,11 @@
 require 'after_party'
-require 'after_party'
 require 'rails'
 module AfterParty
   class Railtie < Rails::Railtie
     #railtie is loaded from lib/after_party.rb.  So all load paths need to be relative to /lib
     rake_tasks do
       load "tasks/deploy_task_runner.rake"
+      load "tasks/reset_task_runner.rake"
     end
 
     initializer "load_task_record_models" do

--- a/lib/tasks/reset_task_runner.rake
+++ b/lib/tasks/reset_task_runner.rake
@@ -1,0 +1,14 @@
+namespace :after_party do
+
+  # Use this task if you want to clear the table that After Party uses to track
+  # the tasks that have already been run.  This allows you to execute rake after_party:run
+  # and re-run all of the tasks (which is useful in development).
+
+  desc "resets the database so all tasks can be run again"
+  task :reset => :environment do
+
+    TaskRecord.delete_all
+    puts (TaskRecord.count == 0 ? "Success!  You may now rerun all tasks using 'rake after_party:run'" : "There was a problem during the reset (the task_record table should be empty, but it is not).")
+    
+  end
+end


### PR DESCRIPTION
This a great gem and I've been using it on one of our projects at work.  The workflow we're using made it necessary to re run all of the tasks while we're in development (prior to launching the app) and we decided to implement a `rake after_party:reset` command to help.  This saves us from having to rebuild the database or manually edit the task_records table each time we want to test something out.

Thanks for creating this gem and please let me know if there's anything you would like me to revise.