### PR TITLE
Remove active record dpendency

### DIFF
--- a/after_party.gemspec
+++ b/after_party.gemspec
@@ -13,7 +13,8 @@ Gem::Specification.new do |gem|
   gem.files = Dir['lib/**/**']
   gem.require_path = 'lib'
 
-  gem.add_dependency 'activerecord'
+  gem.add_development_dependency "activerecord"
+  gem.add_development_dependency "mongoid"
   gem.add_development_dependency "rspec"
   gem.add_development_dependency "rspec-rails", "~> 2.0"
   gem.add_development_dependency "generator_spec"


### PR DESCRIPTION
There is no reason to require active record, since it might be used with monogid.