### PR TITLE
Add pretask feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: ruby
+rvm:
+ - "2.2.5"
+
+script: bundle exec rake spec

--- a/README.md
+++ b/README.md
@@ -75,6 +75,24 @@ after  'deploy:update_code', 'db:migrate', 'db:seed', 'deploy:after_party'
 
 This will ensure your deploy tasks always run after your migrations, so they can safely load or interact with any models in your system.
 
+## pre-tasks
+Additionally, there are a set of tasks that can be separated from the regular tasks to run as pre-deployment tasks.  This can be useful
+when you want the same mechanism of tracking when a task has run to avoid re-runs.
+
+To enable, modify the after_party initializer.
+``` ruby
+AfterParty.setup do |config|
+  # [...]
+  config.enable_pretasks = true
+end
+```
+
+Then tasks that start with the string, `pretask`, are hidden from the regular task runner and status view. Instead
+are run and viewed from `after_part:pretask:run` and `after_part:pretask:status`.  Create the tasks using the same task generator,
+just simply start the name with `pretask`.
+
+These pre-tasks share the same version table and location in `lib/tasks/deployment`.
+
 ## Asyncronous runs
 
 Well yes, a long-running deploy task will halt your deployment, thanks for noticing.  Sometimes you might want your task to finish before you switch the symlink and your new code is in production.  Sometimes, you just want to start the task, and forget about it.  In that case do this:

--- a/after_party.gemspec
+++ b/after_party.gemspec
@@ -13,8 +13,8 @@ Gem::Specification.new do |gem|
   gem.files = Dir['lib/**/**']
   gem.require_path = 'lib'
 
-  gem.add_development_dependency "activerecord"
-  gem.add_development_dependency "mongoid"
+  gem.add_development_dependency "activerecord", '~> 4'
+  gem.add_development_dependency "mongoid", '~> 5'
   gem.add_development_dependency "rspec"
   gem.add_development_dependency "rspec-rails", "~> 3.4"
   gem.add_development_dependency "generator_spec"

--- a/lib/after_party.rb
+++ b/lib/after_party.rb
@@ -1,7 +1,14 @@
 module AfterParty
   require "after_party/railtie.rb" if defined?(Rails)
 
+  mattr_accessor :enable_pretasks
+
   def self.setup
     yield self
   end
+
+  def self.enable_pretasks?
+    enable_pretasks
+  end
+
 end

--- a/lib/generators/install/templates/after_party.rb
+++ b/lib/generators/install/templates/after_party.rb
@@ -4,4 +4,6 @@ AfterParty.setup do |config|
   # :mongoid (bson_ext recommended) by default. Other ORMs may be
   # available as additional gems.
   require "after_party/<%= orm_name %>.rb"
+
+  # config.enable_pretasks = true
 end

--- a/lib/tasks/deploy_task_runner.rake
+++ b/lib/tasks/deploy_task_runner.rake
@@ -15,12 +15,13 @@ namespace :after_party do
   task :status => :environment do
     tasks = Dir[AfterParty::TaskRecorder::FILE_MASK].collect do |filename|
       recorder = AfterParty::TaskRecorder.new(filename)
-      {
+      task_obj = {
         version: recorder.timestamp,
         task_name: recorder.task_name.humanize,
         status: recorder.pending? ? 'down' : ' up '
       }
-    end
+      recorder.post_task? ? task_obj : nil
+    end.compact
 
     puts <<-EOF
 Status   Task ID         Task Name
@@ -29,5 +30,46 @@ Status   Task ID         Task Name
     tasks.each do |task|
       puts " #{task[:status]}    #{task[:version]}  #{task[:task_name].capitalize}"
     end
+  end
+
+  namespace :pretask do
+    desc "runs (in order) all pending after_party pre-deployment tasks, if they have not run yet against the current db."
+    task :run => :environment do
+      tasks = AfterParty::TaskRecorder.pending_pretask_files.map {|f| "after_party:#{f.task_name}"}
+
+      tasks.each {|t| Rake::Task[t].invoke}
+
+      if tasks.empty?
+        puts "no pending tasks to run"
+      end
+
+    end
+
+    desc "Check the status of after_party pre-deployment tasks"
+    task :status => :environment do
+      tasks = Dir[AfterParty::TaskRecorder::FILE_MASK].collect do |filename|
+        recorder = AfterParty::TaskRecorder.new(filename)
+        task_obj = {
+          version: recorder.timestamp,
+          task_name: recorder.task_name.humanize,
+          status: recorder.pending? ? 'down' : ' up '
+        }
+        if AfterParty.enable_pretasks?
+          recorder.post_task? ? nil : task_obj
+        else
+          nil
+        end
+      end.compact
+
+      puts "Note: pretasks are not enabled.  set 'config.enable_pretasks = true' in the initializer to use pre-tasks" if !AfterParty.enable_pretasks?
+      puts <<-EOF
+Status   Task ID         Task Name
+--------------------------------------------------
+      EOF
+      tasks.each do |task|
+        puts " #{task[:status]}    #{task[:version]}  #{task[:task_name].capitalize}"
+      end
+    end
+
   end
 end

--- a/spec/models/task_record_spec.rb
+++ b/spec/models/task_record_spec.rb
@@ -19,6 +19,9 @@ module AfterParty
       File.open(File.join(FILE_PATH, "20120205141454_m_three.rake"), "w+") do |f|
         f.write("this is some contents for file 3")
       end
+      File.open(File.join(FILE_PATH, "20120105141454_pretask_four.rake"), "w+") do |f|
+        f.write("this is some contents for file 4")
+      end
       silence_warnings do
         TaskRecorder::FILE_MASK = File.join(FILE_PATH, "/*.rake")
       end
@@ -26,6 +29,7 @@ module AfterParty
     end
 
     it "should return an ordered list of pending tasks" do
+      allow(AfterParty).to receive(:enable_pretasks?).and_return(true)
       list = AfterParty::TaskRecorder.pending_files
       expect(list.count).to eq(3)
 
@@ -35,6 +39,7 @@ module AfterParty
     end
 
     it "should not include tasks that have already been recorded in the database" do
+      allow(AfterParty).to receive(:enable_pretasks?).and_return(true)
       a = build :task_record, :version => "20120205141454"
       b = build :task_record, :version => "20130207948264"
       expect(AfterParty::TaskRecord).to receive(:all).at_least(:once).and_return([a, b])

--- a/spec/models/task_record_spec.rb
+++ b/spec/models/task_record_spec.rb
@@ -26,21 +26,21 @@ module AfterParty
     end
 
     it "should return an ordered list of pending tasks" do
-      list = TaskRecorder.pending_files
-      list.count.should == 3
+      list = AfterParty::TaskRecorder.pending_files
+      expect(list.count).to eq(3)
 
-      list.first.filename.should =~ /20120205141454_m_three.rake/
-      list[1].filename.should =~ /20130205176456_z_first.rake/
-      list[2].filename.should =~ /20130207948264_a_second2.rake/
+      expect(list.first.filename).to match /20120205141454_m_three.rake/
+      expect(list[1].filename).to match /20130205176456_z_first.rake/
+      expect(list[2].filename).to match /20130207948264_a_second2.rake/
     end
 
     it "should not include tasks that have already been recorded in the database" do
       a = build :task_record, :version => "20120205141454"
       b = build :task_record, :version => "20130207948264"
-      TaskRecord.stub(:all).and_return([a, b])
-      list = TaskRecorder.pending_files
-      list.count.should == 1
-      list.first.filename.should =~ /20130205176456_z_first.rake/
+      expect(AfterParty::TaskRecord).to receive(:all).at_least(:once).and_return([a, b])
+      list = AfterParty::TaskRecorder.pending_files
+      expect(list.count).to eq(1)
+      expect(list.first.filename).to match /20130205176456_z_first.rake/
 
     end
 

--- a/spec/rake_tasks/status_spec.rb
+++ b/spec/rake_tasks/status_spec.rb
@@ -6,29 +6,63 @@ require "fileutils"
 describe "rake after_party:status" do
   include FileUtils
 
-  context "Given we have both ran tasks and tasks to run" do
-    before do
-      AfterParty::Application.load_tasks
-
+  before(:each) do
+    silence_warnings do
       FILE_PATH = File.join(Rails.root, "spec/tmp/lib/tasks/deployment/")
-      rm_rf(FILE_PATH)
-      mkdir_p(FILE_PATH)
-      File.open(File.join(FILE_PATH, "20130205176456_z_first.rake"), "w+") do |f|
-        f.write("this is some contents for file 1")
-      end
-      File.open(File.join(FILE_PATH, "20130207948264_a_second2.rake"), "w+") do |f|
-        f.write("this is some contents for file 2")
-      end
-      File.open(File.join(FILE_PATH, "20120205141454_m_three.rake"), "w+") do |f|
-        f.write("this is some contents for file 3")
-      end
-      silence_warnings do
-        AfterParty::TaskRecorder::FILE_MASK = File.join(FILE_PATH, "/*.rake")
-      end
+    end
 
-      a = FactoryGirl.build :task_record, :version => "20120205141454"
-      b = FactoryGirl.build :task_record, :version => "20130207948264"
-      allow(AfterParty::TaskRecord).to receive(:all) { [a, b] }
+    rm_rf(FILE_PATH)
+    mkdir_p(FILE_PATH)
+    File.open(File.join(FILE_PATH, "20130205176456_z_first.rake"), "w+") do |f|
+      f.write("this is some contents for file 1")
+    end
+    File.open(File.join(FILE_PATH, "20130207948264_a_second2.rake"), "w+") do |f|
+      f.write("this is some contents for file 2")
+    end
+    File.open(File.join(FILE_PATH, "20120205141454_m_three.rake"), "w+") do |f|
+      f.write("this is some contents for file 3")
+    end
+    File.open(File.join(FILE_PATH, "20120105141454_pretask_four.rake"), "w+") do |f|
+      f.write("this is some contents for file 4")
+    end
+    silence_warnings do
+      AfterParty::TaskRecorder::FILE_MASK = File.join(FILE_PATH, "/*.rake")
+    end
+  end
+
+  before(:each) do
+    AfterParty::Application.load_tasks
+    a = FactoryGirl.build :task_record, :version => "20120205141454"
+    b = FactoryGirl.build :task_record, :version => "20130207948264"
+    allow(AfterParty::TaskRecord).to receive(:all) { [a, b] }
+  end
+
+  after(:each) do
+    Rake.application.clear
+  end
+
+  context "Given we have both pending and ran tasks, and pretasks disabled" do
+    before do
+      AfterParty.enable_pretasks = false
+    end
+
+    it "should output all the tasks" do
+      expected_output = <<-EOF
+Status   Task ID         Task Name
+--------------------------------------------------
+ down    20120105141454  Pretask four
+  up     20120205141454  M three
+ down    20130205176456  Z first
+  up     20130207948264  A second2
+      EOF
+
+      expect { Rake::Task["after_party:status"].invoke }.to output(/#{expected_output}/).to_stdout
+    end
+  end
+
+  context "Given we have both ran tasks and tasks to run with pretasks enabled" do
+    before do
+      AfterParty.enable_pretasks = true
     end
 
     it "should output the proper output" do
@@ -42,4 +76,20 @@ Status   Task ID         Task Name
       expect { Rake::Task["after_party:status"].invoke }.to output(/#{expected_output}/).to_stdout
     end
   end
+
+  context "Given we have pretasks left to run" do
+    before do
+      AfterParty.enable_pretasks = true
+    end
+
+    it "should output the proper output" do
+      expected_output = <<-EOF
+Status   Task ID         Task Name
+--------------------------------------------------
+ down    20120105141454  Pretask four
+      EOF
+      expect { Rake::Task["after_party:pretask:status"].invoke }.to output(/#{expected_output}/).to_stdout
+    end
+  end
+
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,6 @@
 ENV["RAILS_ENV"] ||= 'test'
 require File.expand_path("../../config/environment", __FILE__)
 require 'rspec/rails'
-require 'rspec/autorun'
 require 'factory_girl'
 
 Dir[Rails.root.join("lib/after_party/models/*.rb")].each {|f| require f}


### PR DESCRIPTION
```
Adding new pre-task feature.

This is disabled by default (for backwards compatibility), but when
enabled, allows filtering of tasks that start with the name, 'pretask'
to be hidden from the regular after_party run and status tasks.

Instead they will get run in a new 'after_party:pretask' namespace, with
the same tasks, `run` and `status` that are specific to the pretask
namespace.
```
