### PR TITLE
Remove double space in task template

### DIFF
--- a/lib/generators/task/templates/deploy.txt.erb
+++ b/lib/generators/task/templates/deploy.txt.erb
@@ -8,5 +8,5 @@ namespace :after_party do
     # Update task as completed.  If you remove the line below, the task will
     # run with every deploy (or every time you call after_party:run).
     AfterParty::TaskRecord.create version: '<%= timestamp %>'
-  end  # task :<%= file_name %>
-end  # namespace :after_party
+  end # task :<%= file_name %>
+end # namespace :after_party


### PR DESCRIPTION
My rubocop was complaining about this double space every time so here is the easy fix! Thanks for this awesome Gem!!