### PR TITLE
Add Specifying Rails Version to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,32 @@ rails generate after_party:install
 rake db:migrate
 ```
 
+You might also need to specify the version of Rails in your migration file rather than inheriting from the base ActiveRecord class. For example, if you are using Rails 5:
+
+Change this:
+
+```
+class CreateTaskRecords < ActiveRecord::Migration
+  def change
+    create_table :task_records, :id => false do |t|
+      t.string :version, :null => false
+    end
+  end
+end
+```
+
+To this:
+
+```
+class CreateTaskRecords < ActiveRecord::Migration[5.0]
+  def change
+    create_table :task_records, :id => false do |t|
+      t.string :version, :null => false
+    end
+  end
+end
+```
+
 
 If you are using Mongoid, run the install generator with "mongoid" as the first argument
 


### PR DESCRIPTION
When I tried to rebuild my database, I received an error saying that one should add the specific rails version to the migration file rather than ActiveRecord base class. I thought it would be convenient from a developer standpoint to have that right on the first page of the readme.