### PR TITLE
Remove whitespace to play nice with RuboCop.

### DIFF
--- a/lib/generators/task/templates/deploy.txt.erb
+++ b/lib/generators/task/templates/deploy.txt.erb
@@ -9,5 +9,5 @@ namespace :after_party do
     # run with every deploy (or every time you call after_party:run).
     AfterParty::TaskRecord
       .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
-  end  # task :<%= file_name %>
-end  # namespace :after_party
+  end # task :<%= file_name %>
+end # namespace :after_party


### PR DESCRIPTION
This is was already committed and merged, but PR #32 regressed the fix.

Currently, the auto-generated task includes 2 whitespaces for end scope
comments. The default settings for the most used Ruby linter, RuboCop
(https://github.com/rubocop-hq/rubocop), specifies only 1 space before
comments. Who cares about these characters? Only those of us who use
RuboCop.