### PR TITLE
doc: modify capistrano hook example

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Finally, You'll want to glue this all together.  Update the deploy.rb (or whatev
    end
  end
 
-after  'deploy:update_code', 'db:migrate', 'db:seed', 'deploy:after_party'
+after 'deploy:migrate', 'deploy:after_party'
 ```
 
 This will ensure your deploy tasks always run after your migrations, so they can safely load or interact with any models in your system.


### PR DESCRIPTION
There's no `deploy:update_code', 'db:migrate', 'db:seed'` in capistrano deploy hook. Execute`after_party:run` `after deploy:migrate` instead.

```
deploy
  deploy:starting
    [before]
      deploy:ensure_stage
      deploy:set_shared_assets
    deploy:check
  deploy:started
  deploy:updating
    git:create_release
    deploy:symlink:shared
  deploy:updated
    [before]
      deploy:bundle
    [after]
      deploy:migrate
      deploy:compile_assets
      deploy:normalize_assets
  deploy:publishing
    deploy:symlink:release
  deploy:published
  deploy:finishing
    deploy:cleanup
  deploy:finished
    deploy:log_revision
```

https://capistranorb.com/documentation/getting-started/flow/