### PR TITLE
Encapsulate Task Run Tracking into Helper Method.

### DIFF
--- a/lib/after_party/models/active_record/task_record.rb
+++ b/lib/after_party/models/active_record/task_record.rb
@@ -6,5 +6,9 @@ module AfterParty
     def self.completed_task?(version)
       all.any? { |t| t.version == version }
     end
+
+    def self.record_task_run(filename)
+      create(version: AfterParty::TaskRecorder.new(__FILE__).timestamp)
+    end
   end
 end

--- a/lib/after_party/models/mongoid/task_record.rb
+++ b/lib/after_party/models/mongoid/task_record.rb
@@ -9,5 +9,9 @@ module AfterParty
     def self.completed_task?(version)
       all.any? { |t| t.version == version }
     end
+
+    def self.record_task_run(filename)
+      create(version: AfterParty::TaskRecorder.new(__FILE__).timestamp)
+    end
   end
 end

--- a/lib/generators/task/templates/deploy.txt.erb
+++ b/lib/generators/task/templates/deploy.txt.erb
@@ -7,7 +7,6 @@ namespace :after_party do
 
     # Update task as completed.  If you remove the line below, the task will
     # run with every deploy (or every time you call after_party:run).
-    AfterParty::TaskRecord
-      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+    AfterParty::TaskRecord.record_task_run(__FILE__)
   end
 end

--- a/spec/fixtures/tasks/deployment/20120205141454_m_three.rake
+++ b/spec/fixtures/tasks/deployment/20120205141454_m_three.rake
@@ -5,7 +5,6 @@ namespace :after_party do
 
     # Update task as completed.  If you remove the line below, the task will
     # run with every deploy (or every time you call after_party:run).
-    AfterParty::TaskRecord
-      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+    AfterParty::TaskRecord.record_task_run(__FILE__)
   end
 end

--- a/spec/fixtures/tasks/deployment/20130205176456_z_first.rake
+++ b/spec/fixtures/tasks/deployment/20130205176456_z_first.rake
@@ -5,7 +5,6 @@ namespace :after_party do
 
     # Update task as completed.  If you remove the line below, the task will
     # run with every deploy (or every time you call after_party:run).
-    AfterParty::TaskRecord
-      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+    AfterParty::TaskRecord.record_task_run(__FILE__)
   end
 end

--- a/spec/fixtures/tasks/deployment/20130207948264_a_second2.rake
+++ b/spec/fixtures/tasks/deployment/20130207948264_a_second2.rake
@@ -5,7 +5,6 @@ namespace :after_party do
 
     # Update task as completed.  If you remove the line below, the task will
     # run with every deploy (or every time you call after_party:run).
-    AfterParty::TaskRecord
-      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+    AfterParty::TaskRecord.record_task_run(__FILE__)
   end
 end


### PR DESCRIPTION
## Changes:
- Add `.record_task_run` method to `AfterParty::TaskRecord` model to encapsulate record creation.
- Update task generator template to use helper method.
- Update fixtures to use helper method.