### PR TITLE
Move requires_version_tag? to private

### DIFF
--- a/lib/generators/install/install_generator.rb
+++ b/lib/generators/install/install_generator.rb
@@ -21,11 +21,11 @@ module AfterParty
         end
       end
 
+      private
+      
       def requires_version_tag?
         ActiveRecord::VERSION::MAJOR >= 5
       end
-
-      private
 
       def timestamp
         @timestamp ||= Time.now.utc.strftime('%Y%m%d%H%M%S')


### PR DESCRIPTION
As Thor automatically makes all public methods of the generator into commands, mongoid projects, which don't have `ActiveRecord` defined, get the following error when running the `install` generator:

`'requires_version_tag?': uninitialized constant AfterParty::Generators::InstallGenerator::ActiveRecord (NameError)`

It does create the initializer, so nothing is really broken, but it's confusing and feels like a bug 🙂