### PR TITLE
Check if task is pending just before run

### DIFF
--- a/lib/tasks/deploy_task_runner.rake
+++ b/lib/tasks/deploy_task_runner.rake
@@ -3,7 +3,11 @@ namespace :after_party do
   task :run => :environment do
     tasks = AfterParty::TaskRecorder.pending_files.map { |f| "after_party:#{f.task_name}" }
 
-    tasks.each { |t| Rake::Task[t].invoke }
+    tasks.each do |t|
+      if t.pending? then
+        Rake::Task[t].invoke
+      end
+    end
 
     puts 'no pending tasks to run' if tasks.empty?
   end


### PR DESCRIPTION
## Description

Check if a task is pending the moment before executing it instead of checking for all pending tasks, then running all of them.

In the current version, when you run 'rake after_party:run', it collects all the pending tasks and queues them up. In the suggested change, it also does another check of each task before executing that task.

## Why

We have a use case where we want to skip existing after_party tasks when starting a new environment, but then run all subsequent after party tasks. We accomplish this with something like this:

```
namespace :after_party do
  desc 'Deployment task: mark_all_tasks_run'
  task mark_all_tasks_run: :environment do

    Dir.glob("#{Rails.root}/lib/tasks/deployment/*").each do |file_name|
      puts "Marking #{file_name} as already run."
      AfterParty::TaskRecord.create(version: AfterParty::TaskRecorder.new(file_name.split('/').last).timestamp)
    end

    AfterParty::TaskRecord
      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
  end
end
```